### PR TITLE
Fix: Prevent horizontal scroll on mobile blog pages

### DIFF
--- a/src/app/blog-styles.css
+++ b/src/app/blog-styles.css
@@ -48,7 +48,8 @@
   /* background-color: theme('colors.gray.100'); */
   /* padding: 1em; */
   /* border-radius: 0.375rem; */
-  /* overflow-x: auto; */
+  overflow-x: auto; /* Ensure this is active */
+  max-width: 100%; /* Added for responsiveness */
 }
 
 .blog-content code {
@@ -67,6 +68,7 @@
   border-collapse: collapse;
   font-size: 0.9em;
   border: 1px solid #e5e7eb; /* Added a border to the table itself */
+  table-layout: fixed; /* Added for fixed table layout */
 }
 
 .blog-content th,


### PR DESCRIPTION
Addresses an issue where blog posts and the main blog page could exhibit horizontal scrolling on mobile devices.

The following CSS changes were made to `src/app/blog-styles.css`:
- For tables within `.blog-content`:
  - Added `table-layout: fixed;` to ensure tables respect the width of their container and prevent wide content from causing page overflow.
- For preformatted text (code blocks) within `.blog-content`:
  - Added `max-width: 100%;` to ensure the <pre> element itself does not exceed the width of its container.
  - Ensured `overflow-x: auto;` is active so that wide code content becomes scrollable within the code block rather than causing page overflow.

These changes improve the mobile reading experience by making blog content more responsive.