### PR TITLE
feat: Add integrations toast notification to blog posts

### DIFF
--- a/src/app/(app)/blog/[slug]/page.tsx
+++ b/src/app/(app)/blog/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import { getAllPostSlugs, getPostData, PostData } from '@/lib/posts';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import IntegrationsToast from '@/components/shared/IntegrationsToast';
 import { Metadata } from 'next';
 
 // This function is needed for Next.js to know which slugs are available at build time
@@ -163,6 +164,7 @@ export default async function PostPage({ params }: { params: { slug: string } })
           </Link>
         </div>
       </article>
+      <IntegrationsToast />
     </div>
   );
 } 

--- a/src/components/shared/IntegrationsToast.tsx
+++ b/src/components/shared/IntegrationsToast.tsx
@@ -1,0 +1,35 @@
+import React, { useState, useEffect } from 'react';
+import Link from 'next/link';
+
+const IntegrationsToast: React.FC = () => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setVisible(true);
+    }, 10000); // 10-second delay
+
+    return () => clearTimeout(timer);
+  }, []);
+
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <div className="fixed bottom-4 right-4 bg-white p-4 rounded-lg shadow-md flex items-center space-x-4">
+      <span>Have you checked out our integrations?</span>
+      <Link href="/integrations" className="text-blue-500 hover:underline">
+        Learn more
+      </Link>
+      <button
+        onClick={() => setVisible(false)}
+        className="text-gray-500 hover:text-gray-700"
+      >
+        &times; {/* X icon */}
+      </button>
+    </div>
+  );
+};
+
+export default IntegrationsToast;

--- a/src/components/shared/IntegrationsToast.tsx
+++ b/src/components/shared/IntegrationsToast.tsx
@@ -1,3 +1,4 @@
+"use client";
 import React, { useState, useEffect } from 'react';
 import Link from 'next/link';
 


### PR DESCRIPTION
Added a toast notification to blog post pages to encourage you to visit the integrations page.

The notification appears in the lower right corner after a 10-second delay and can be dismissed by you.

A new component `IntegrationsToast.tsx` was created for this notification.